### PR TITLE
Export main class in `jvm_binary` targets

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_fastpass.py
+++ b/src/python/pants/backend/project_info/tasks/export_fastpass.py
@@ -17,6 +17,7 @@ from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_app import JvmApp
+from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
@@ -361,6 +362,11 @@ class ExportFastpassTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixi
                 except:
                     pass # ignore
                 # - export deviation
+
+            # + export deviation
+            if isinstance(current_target, JvmBinary):
+                info["main_class"] = current_target.main
+            # - export deviation
 
             info["roots"] = [
                 {


### PR DESCRIPTION
### Problem

Previously, the export from `export-fastpass` didn't include the name of the
main class for `jvm_binary` targets. For targets with multiple `main`s, or
targets whose `main` is defined in a dependency, couldn't easily be run by
Bloop (the main class would have to be manually specified).

### Solution

This commit adds this information for `jvm_binary` targets.

### Result

The information can be passed on to Bloop.